### PR TITLE
FIX: Trying to get property 'firstChild' of non-object

### DIFF
--- a/src/HTML5DOMDocument.php
+++ b/src/HTML5DOMDocument.php
@@ -123,11 +123,18 @@ class HTML5DOMDocument extends \DOMDocument
                 $headElement = $metaTagElement->parentNode;
                 $htmlElement = $headElement->parentNode;
                 $metaTagElement->parentNode->removeChild($metaTagElement);
-                if ($removeHeadTag && $headElement->firstChild === null) {
-                    $headElement->parentNode->removeChild($headElement);
+                if(is_object($metaTagElement))
+                {
+                    if ($removeHeadTag && $headElement->firstChild === null) {
+                        $headElement->parentNode->removeChild($headElement);
+                    }
                 }
-                if ($removeHtmlTag && $htmlElement->firstChild === null) {
-                    $htmlElement->parentNode->removeChild($htmlElement);
+                $htmlElement = $headElement->parentNode;
+                if(is_object($htmlElement))
+                {
+                    if ($removeHtmlTag && $htmlElement->firstChild === null) {
+                        $htmlElement->parentNode->removeChild($htmlElement);
+                    }
                 }
             }
         }


### PR DESCRIPTION
When I use `$doc->loadHTML($html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);` on one string without `<body>` like:
`Testing string`

 I get this error:
`Error:(Notice) [Trying to get property 'firstChild' of non-object] (Num 8) en el fichero: [\ivopetkov\html5-dom-document-php\src\HTML5DOMDocument.php] (Linea: 129)`

Fixed to check that `$metaTagElement` and `$htmlElement` are objects before access to them