### PR TITLE
Remove added temporary DOCTYPE

### DIFF
--- a/src/HTML5DOMDocument.php
+++ b/src/HTML5DOMDocument.php
@@ -72,8 +72,11 @@ class HTML5DOMDocument extends \DOMDocument
             $source = '<body>' . $source . '</body>';
         }
 
+        // Adds temporary DOCTYPE
+        $removeDocType=false;
         if (strtoupper(substr($source, 0, 9)) !== '<!DOCTYPE') {
             $source = '<!DOCTYPE html>' . $source;
+            $removeDocType=true;
         }
 
         // Adds temporary head tag
@@ -130,6 +133,12 @@ class HTML5DOMDocument extends \DOMDocument
                     $htmlElement->parentNode->removeChild($htmlElement);
                 }
             }
+        }
+
+        // Remove temporary DOCTYPE
+        if($removeDocType)
+        {
+            $this->removeChild($this->doctype);            
         }
 
         if (!$isSavedHTML) {


### PR DESCRIPTION
I'm using this library in my custom templates library. I read files with html pieces that do not need a concrete structure and that are going to be inserted inside another html text. Therefore, I need to maintain the original structure and not add extra elements. 
Therefore, if a tag or temporary element is added, the ideal is to erase it when it is no longer necessary.