### PR TITLE
Allow multiple attribute selection

### DIFF
--- a/src/HTML5DOMDocument/Internal/QuerySelectors.php
+++ b/src/HTML5DOMDocument/Internal/QuerySelectors.php
@@ -90,7 +90,7 @@ trait QuerySelectors
         } elseif (preg_match('/^([a-z0-9]*)((\[([^\]]+)\=\"([^\]]+)\"\])*)$/', $selector, $matches) === 1) { // tagname[attribute="value"] or [attribute="value"]
             $tagName = strlen($matches[1]) > 0 ? $matches[1] : null;
             // Extract potentially multiple attributes.
-            $attributes = preg_match_all('/\[([^\]]+)\=\"([^\]]+)\"\]/', $matches[2], $attrMatches, PREG_SET_ORDER);
+            preg_match_all('/\[([^\]]+)\=\"([^\]]+)\"\]/', $matches[2], $attrMatches, PREG_SET_ORDER);
             $result = [];
             $walkChildren($this, $tagName, function($element) use (&$result, $preferredLimit, $matches, $attrMatches) {
                 if ($element->attributes->length < 1) {

--- a/src/HTML5DOMDocument/Internal/QuerySelectors.php
+++ b/src/HTML5DOMDocument/Internal/QuerySelectors.php
@@ -87,15 +87,24 @@ trait QuerySelectors
                 }
             });
             return new \IvoPetkov\HTML5DOMNodeList($result);
-        } elseif (preg_match('/^([a-z0-9\-]*)\[(.+)\=\"(.+)\"\]$/', $selector, $matches) === 1) { // tagname[attribute="value"] or [attribute="value"]
-            $result = [];
+        } elseif (preg_match('/^([a-z0-9]*)((\[([^\]]+)\=\"([^\]]+)\"\])*)$/', $selector, $matches) === 1) { // tagname[attribute="value"] or [attribute="value"]
             $tagName = strlen($matches[1]) > 0 ? $matches[1] : null;
-            $walkChildren($this, $tagName, function($element) use (&$result, $preferredLimit, $matches) {
-                if ($element->attributes->length > 0 && $element->getAttribute($matches[2]) === $matches[3]) {
-                    $result[] = $element;
-                    if ($preferredLimit !== null && sizeof($result) >= $preferredLimit) {
-                        return true;
+            // Extract potentially multiple attributes.
+            $attributes = preg_match_all('/\[([^\]]+)\=\"([^\]]+)\"\]/', $matches[2], $attrMatches, PREG_SET_ORDER);
+            $result = [];
+            $walkChildren($this, $tagName, function($element) use (&$result, $preferredLimit, $matches, $attrMatches) {
+                if ($element->attributes->length < 1) {
+                    return;
+                }
+                // Check that all specified attributes match.
+                foreach ($attrMatches as $attrMatch) {
+                    if ($element->getAttribute($attrMatch[1]) !== $attrMatch[2]) {
+                        return;
                     }
+                }
+                $result[] = $element;
+                if ($preferredLimit !== null && sizeof($result) >= $preferredLimit) {
+                    return true;
                 }
             });
             return new \IvoPetkov\HTML5DOMNodeList($result);

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -383,13 +383,16 @@ class Test extends HTML5DOMDocumentTestCase
     }
 
     /**
-     * 
+     *
      */
     public function testElementQuerySelector()
     {
 
         $dom = new HTML5DOMDocument();
-        $dom->loadHTML('<html><body><div id="container">'
+        $dom->loadHTML('<html><head>'
+                . '<link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">'
+                . '<link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32"></head>'
+                . '<body><div id="container">'
                 . '<div id="text1" class="class1">text1</div>'
                 . '<div>text2</div>'
                 . '<div>'
@@ -411,6 +414,10 @@ class Test extends HTML5DOMDocumentTestCase
         $this->assertTrue($dom->querySelector('#container')->querySelectorAll('span#text4')->item(0)->innerHTML === 'text4');
         $this->assertTrue($dom->querySelector('#container')->querySelectorAll('[id="text4"]')->item(0)->innerHTML === 'text4');
         $this->assertTrue($dom->querySelector('#container')->querySelectorAll('span[id="text4"]')->item(0)->innerHTML === 'text4');
+        $this->assertEquals('/favicon-16x16.png', $dom->querySelectorAll('link[rel="icon"]')->item(0)->getAttribute('href'));
+        $this->assertEquals('/favicon-32x32.png', $dom->querySelectorAll('link[rel="icon"]')->item(1)->getAttribute('href'));
+        $this->assertEquals('/favicon-16x16.png', $dom->querySelectorAll('link[rel="icon"][sizes="16x16"]')->item(0)->getAttribute('href'));
+        $this->assertNull($dom->querySelectorAll('link[rel="icon"][sizes="16x16"]')->item(1));
         $this->assertTrue($dom->querySelector('#container')->querySelectorAll('div#text4')->length === 0);
         $this->assertTrue($dom->querySelector('#container')->querySelectorAll('div.class1')->length === 2);
         $this->assertTrue($dom->querySelector('#container')->querySelectorAll('.class1')->length === 4);


### PR DESCRIPTION
Adds support for multiple attribute selectors, e.g.

```
$dom->querySelector('link[rel="icon"][sizes="192x192"]')
```

Fixes #11 