### PR TITLE
Adds phpdoc to better identify the values returned.

### DIFF
--- a/src/HTML5DOMDocument.php
+++ b/src/HTML5DOMDocument.php
@@ -386,7 +386,7 @@ class HTML5DOMDocument extends \DOMDocument
      * Returns the first document element matching the selector.
      *
      * @param string $selector A CSS query selector. Available values: *, tagname, tagname#id, #id, tagname.classname, .classname, tagname.classname.classname2, .classname.classname2, tagname[attribute-selector], [attribute-selector], "div, p", div p, div > p, div + p and p ~ ul.
-     * @return \DOMElement|null The result DOMElement or null if not found.
+     * @return HTML5DOMElement|null The result DOMElement or null if not found.
      * @throws \InvalidArgumentException
      */
     public function querySelector(string $selector)
@@ -398,7 +398,7 @@ class HTML5DOMDocument extends \DOMDocument
      * Returns a list of document elements matching the selector.
      *
      * @param string $selector A CSS query selector. Available values: *, tagname, tagname#id, #id, tagname.classname, .classname, tagname.classname.classname2, .classname.classname2, tagname[attribute-selector], [attribute-selector], "div, p", div p, div > p, div + p and p ~ ul.
-     * @return \DOMNodeList Returns a list of DOMElements matching the criteria.
+     * @return HTML5DOMNodeList Returns a list of DOMElements matching the criteria.
      * @throws \InvalidArgumentException
      */
     public function querySelectorAll(string $selector)
@@ -410,7 +410,7 @@ class HTML5DOMDocument extends \DOMDocument
      * Creates an element that will be replaced by the new body in insertHTML.
      *
      * @param string $name The name of the insert target.
-     * @return \DOMElement A new DOMElement that must be set in the place where the new body will be inserted.
+     * @return HTML5DOMElement A new DOMElement that must be set in the place where the new body will be inserted.
      */
     public function createInsertTarget(string $name)
     {

--- a/src/HTML5DOMDocument/Internal/QuerySelectors.php
+++ b/src/HTML5DOMDocument/Internal/QuerySelectors.php
@@ -2,6 +2,8 @@
 
 namespace IvoPetkov\HTML5DOMDocument\Internal;
 
+use IvoPetkov\HTML5DOMElement;
+
 trait QuerySelectors
 {
 
@@ -9,7 +11,7 @@ trait QuerySelectors
      * Returns the first element matching the selector.
      * 
      * @param string $selector A CSS query selector. Available values: *, tagname, tagname#id, #id, tagname.classname, .classname, tagname[attribute-selector] and [attribute-selector].
-     * @return \DOMElement|null The result DOMElement or null if not found
+     * @return HTML5DOMElement|null The result DOMElement or null if not found
      */
     private function internalQuerySelector(string $selector)
     {

--- a/src/HTML5DOMElement.php
+++ b/src/HTML5DOMElement.php
@@ -197,7 +197,7 @@ class HTML5DOMElement extends \DOMElement
      * Returns the first child element matching the selector.
      *
      * @param string $selector A CSS query selector. Available values: *, tagname, tagname#id, #id, tagname.classname, .classname, tagname.classname.classname2, .classname.classname2, tagname[attribute-selector], [attribute-selector], "div, p", div p, div > p, div + p and p ~ ul.
-     * @return \DOMElement|null The result DOMElement or null if not found.
+     * @return HTML5DOMElement|null The result DOMElement or null if not found.
      * @throws \InvalidArgumentException
      */
     public function querySelector(string $selector)
@@ -209,7 +209,7 @@ class HTML5DOMElement extends \DOMElement
      * Returns a list of children elements matching the selector.
      *
      * @param string $selector A CSS query selector. Available values: *, tagname, tagname#id, #id, tagname.classname, .classname, tagname.classname.classname2, .classname.classname2, tagname[attribute-selector], [attribute-selector], "div, p", div p, div > p, div + p and p ~ ul.
-     * @return \DOMNodeList Returns a list of DOMElements matching the criteria.
+     * @return HTML5DOMNodeList Returns a list of DOMElements matching the criteria.
      * @throws \InvalidArgumentException
      */
     public function querySelectorAll(string $selector)


### PR DESCRIPTION
For IDEs, it's crucial to have the right class types being specified in the php documentation block; this should help IDEs autocomplete querySelector and other such methods even when dealing with children elements.