### PR TITLE
Adressed Issue #31 with getters

### DIFF
--- a/src/HTML5DOMElement.php
+++ b/src/HTML5DOMElement.php
@@ -153,6 +153,26 @@ class HTML5DOMElement extends \DOMElement
     }
 
     /**
+     * Returns the updated nodeValue Property
+     * 
+     * @return string The updated $nodeValue
+     */
+    public function getNodeValue(): string
+    {
+        return $this->updateResult($this->nodeValue);
+    }
+
+    /**
+     * Returns the updated $textContent Property
+     * 
+     * @return string The updated $textContent
+     */
+    public function getTextContent(): string
+    {
+        return $this->updateResult($this->textContent);
+    }
+
+    /**
      * Returns the value for the attribute name specified.
      *
      * @param string $name The attribute name.

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -1366,7 +1366,7 @@ class Test extends PHPUnit\Framework\TestCase
     }
 
     /** @dataProvider propertyGetterTestDataProvider */
-    public function testInternalEntityFromGetters(string $dom, string $expectedFromProperty string $expectedFromGetter)
+    public function testInternalEntityFromGetters(string $dom, string $expectedFromProperty, string $expectedFromGetter)
     {
         $domDoc = new HTML5DOMDocument('1.0', 'utf-8');
         $domDoc->loadHTML($dom);

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -1352,4 +1352,29 @@ class Test extends PHPUnit\Framework\TestCase
             $this->assertEquals($fragment, $dom->saveHTML());
         }
     }
+
+    public function testInternalEntityBugWithXPath()
+    {
+        $dom = '<html><body><p><span>Lorem Ipsum</span> &mdash; <span>dolor sit amet,</span></p></body></html>';
+
+        $domDoc = new HTML5DOMDocument('1.0', 'utf-8');
+        $domDoc->loadHTML($dom);
+        $xpath = new DOMXPath($domDoc);
+
+        $xPathNodeList = $xpath->query('//p');
+
+        foreach ($xPathNodeList as $node) {
+            static::assertInstanceOf(HTML5DOMElement::class, $node);
+            static::assertEquals('Lorem Ipsum html5-dom-document-internal-entity1-mdash-end dolor sit amet,', $node->nodeValue);
+            static::assertEquals('Lorem Ipsum &mdash; dolor sit amet,', $node->getNodeValue());
+        }
+
+        $querySelectorNodeList = $domDoc->querySelectorAll('p');
+
+        foreach ($querySelectorNodeList as $node) {
+            static::assertInstanceOf(HTML5DOMElement::class, $node);
+            static::assertEquals('Lorem Ipsum html5-dom-document-internal-entity1-mdash-end dolor sit amet,', $node->nodeValue);
+            static::assertEquals('Lorem Ipsum &mdash; dolor sit amet,', $node->getNodeValue());
+        }
+    }
 }

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -1367,7 +1367,7 @@ class Test extends PHPUnit\Framework\TestCase
         foreach ($xPathNodeList as $node) {
             static::assertInstanceOf(HTML5DOMElement::class, $node);
             static::assertEquals('Lorem Ipsum html5-dom-document-internal-entity1-mdash-end dolor sit amet,', $node->nodeValue);
-            static::assertEquals('Lorem Ipsum &mdash; dolor sit amet,', $node->getNodeValue());
+            static::assertEquals('Lorem Ipsum — dolor sit amet,', $node->getNodeValue());
         }
 
         $querySelectorNodeList = $domDoc->querySelectorAll('p');
@@ -1375,7 +1375,7 @@ class Test extends PHPUnit\Framework\TestCase
         foreach ($querySelectorNodeList as $node) {
             static::assertInstanceOf(HTML5DOMElement::class, $node);
             static::assertEquals('Lorem Ipsum html5-dom-document-internal-entity1-mdash-end dolor sit amet,', $node->nodeValue);
-            static::assertEquals('Lorem Ipsum &mdash; dolor sit amet,', $node->getNodeValue());
+            static::assertEquals('Lorem Ipsum — dolor sit amet,', $node->getNodeValue());
         }
     }
 }

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -1354,10 +1354,20 @@ class Test extends PHPUnit\Framework\TestCase
         }
     }
 
-    public function testInternalEntityBugWithXPath()
+    public function propertyGetterTestDataProvider()
     {
-        $dom = '<html><body><p><span>Lorem Ipsum</span> &mdash; <span>dolor sit amet,</span></p></body></html>';
+      return [
+        [
+            '<html><body><p><span>Lorem Ipsum</span> &mdash; <span>dolor sit amet,</span></p></body></html>',
+            'Lorem Ipsum html5-dom-document-internal-entity1-mdash-end dolor sit amet,',
+            'Lorem Ipsum — dolor sit amet,'
+        ]
+      ];
+    }
 
+    /** @dataProvider propertyGetterTestDataProvider */
+    public function testInternalEntityFromGetters(string $dom, string $expectedFromProperty string $expectedFromGetter)
+    {
         $domDoc = new HTML5DOMDocument('1.0', 'utf-8');
         $domDoc->loadHTML($dom);
         $xpath = new DOMXPath($domDoc);
@@ -1366,16 +1376,22 @@ class Test extends PHPUnit\Framework\TestCase
 
         foreach ($xPathNodeList as $node) {
             static::assertInstanceOf(HTML5DOMElement::class, $node);
-            static::assertEquals('Lorem Ipsum html5-dom-document-internal-entity1-mdash-end dolor sit amet,', $node->nodeValue);
-            static::assertEquals('Lorem Ipsum — dolor sit amet,', $node->getNodeValue());
+            static::assertEquals($expectedFromProperty, $node->nodeValue);
+            static::assertEquals($expectedFromGetter, $node->getNodeValue());
+
+            static::assertEquals($expectedFromProperty, $node->textContent);
+            static::assertEquals($expectedFromGetter, $node->getTextContent());
         }
 
         $querySelectorNodeList = $domDoc->querySelectorAll('p');
 
         foreach ($querySelectorNodeList as $node) {
             static::assertInstanceOf(HTML5DOMElement::class, $node);
-            static::assertEquals('Lorem Ipsum html5-dom-document-internal-entity1-mdash-end dolor sit amet,', $node->nodeValue);
-            static::assertEquals('Lorem Ipsum — dolor sit amet,', $node->getNodeValue());
+            static::assertEquals($expectedFromProperty, $node->nodeValue);
+            static::assertEquals($expectedFromGetter, $node->getNodeValue());
+
+            static::assertEquals($expectedFromProperty, $node->textContent);
+            static::assertEquals($expectedFromGetter, $node->getTextContent());
         }
     }
 }

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -8,6 +8,7 @@
  */
 
 use IvoPetkov\HTML5DOMDocument;
+use IvoPetkov\HTML5DOMElement;
 
 /**
  * @runTestsInSeparateProcesses


### PR DESCRIPTION
I circumvented the Issue by implementing getters for the properties.
`\DomNode::$textContent` => `IvoPetkov\HTML5DOMElement::getTextContent()`
`\DomNode::$nodeValue` => `IvoPetkov\HTML5DOMElement::getNodeValue()`

I also added my TestCases to the Unit Test