### PR TITLE
Modify <html> tag Regex

### DIFF
--- a/src/HTML5DOMDocument.php
+++ b/src/HTML5DOMDocument.php
@@ -139,7 +139,7 @@ class HTML5DOMDocument extends \DOMDocument
             $source = substr($source, 0, $insertPosition) . $charsetTag . substr($source, $insertPosition);
         } else {
             $matches = [];
-            preg_match('/\<html.*?\>/', $source, $matches);
+            preg_match('/\<html(\s.*?\>|\>)/', $source, $matches);
             if (isset($matches[0])) { // has html tag
                 $source = str_replace($matches[0], $matches[0] . '<head>' . $charsetTag . '</head>', $source);
             } else {

--- a/src/HTML5DOMDocument.php
+++ b/src/HTML5DOMDocument.php
@@ -119,7 +119,7 @@ class HTML5DOMDocument extends \DOMDocument
         $allowDuplicateIDs = ($options & self::ALLOW_DUPLICATE_IDS) !== 0;
 
         // Add body tag if missing
-        if ($autoAddHtmlAndBodyTags && $source !== '' && preg_match('/\<!DOCTYPE.*?\>/', $source) === 0 && preg_match('/\<html.*?\>/', $source) === 0 && preg_match('/\<body.*?\>/', $source) === 0 && preg_match('/\<head.*?\>/', $source) === 0) {
+        if ($autoAddHtmlAndBodyTags && $source !== '' && preg_match('/\<!DOCTYPE.*?\>/', $source) === 0 && preg_match('/\<html(\s.*?\>|\>)/', $source) === 0 && preg_match('/\<body.*?\>/', $source) === 0 && preg_match('/\<head.*?\>/', $source) === 0) {
             $source = '<body>' . $source . '</body>';
         }
 


### PR DESCRIPTION
I have a number of
```
<script type="text/template>
  <div>...</div>
</script>
```

The `</div>` is being replaced with `<html5-dom-document-internal-cdata-endtagfix/div>`. This is later tripping the `preg_match('/\<html.*?\>/', $source, $matches);` regex causing an unnecessary replacement.

Due to the ordering these are undone, the resulting html has a number of extra `<head><meta data-html5-dom-document-internal-attribute="charset-meta" http-equiv="content-type" content="text/html; charset=utf-8" />` preceding the `</div>` tags.

I believe the contained changes to the `<html>` match regex fix this issue by requiring the `<html` to be following by a space or `>`.