### PR TITLE
Find empty/boolean attributes in querySelector

### DIFF
--- a/src/HTML5DOMDocument/Internal/QuerySelectors.php
+++ b/src/HTML5DOMDocument/Internal/QuerySelectors.php
@@ -143,6 +143,7 @@ trait QuerySelectors
                 $tagName = strlen($match[1]) > 0 ? strtolower($match[1]) : null;
                 $check = function ($element) use ($attributeSelectors) {
                     if ($element->attributes->length > 0) {
+                        $attributes = $element->getAttributes();
                         foreach ($attributeSelectors as $attributeSelector) {
                             $isMatch = false;
                             $attributeValue = $element->getAttribute($attributeSelector['name']);
@@ -188,6 +189,9 @@ trait QuerySelectors
                             } else {
                                 if ($attributeValue !== '') {
                                     $isMatch = true;
+                                } else {
+                                    $found = array_search($attributeSelector['name'], array_keys($attributes));
+                                    $isMatch = ($found !== FALSE);
                                 }
                             }
                             if (!$isMatch) {

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -344,7 +344,7 @@ class Test extends PHPUnit\Framework\TestCase
             . '<div id="text1" class="class1">text1</div>'
             . '<div>text2</div>'
             . '<div>'
-            . '<div class="text3 class1">text3</div>'
+            . '<div empty-attribute class="text3 class1">text3</div>'
             . '</div>'
             . '<my-custom-element class="text5 class1">text5</my-custom-element>'
             . '<span id="text4" class="class1 class2">text4</div>'
@@ -365,6 +365,7 @@ class Test extends PHPUnit\Framework\TestCase
         $this->assertTrue($dom->querySelectorAll('span[id="text4"]')->item(0)->innerHTML === 'text4');
         $this->assertTrue($dom->querySelectorAll('[id]')->item(0)->innerHTML === 'text1');
         $this->assertTrue($dom->querySelectorAll('[id]')->length === 2);
+        $this->assertTrue($dom->querySelectorAll('[empty-attribute]')->length === 1);
         $this->assertTrue($dom->querySelectorAll('span[id]')->item(0)->innerHTML === 'text4');
         $this->assertTrue($dom->querySelectorAll('span[data-other]')->length === 0);
         $this->assertTrue($dom->querySelectorAll('div#text4')->length === 0);


### PR DESCRIPTION
I have the need to match on 'empty' attribute values, specifically: 

```
<div data-drupal-messages-fallback class="hidden"></div>
```

Attributes with no value also commonly appear as boolean attributes, for example:
```
<input type="checkbox" checked />
```

Currently, ```internalQuerySelectorAll()``` is not matching these attributes.

I have modified ```internalQuerySelectorAll``` to find these 'empty' attributes. 