### PR TITLE
Fix compatibility with libxml 2.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: master
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  php-tests:
+    name: PHP ${{ matrix.php }} Tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.0, 8.1, 8.2, 8.3, 8.4]
+
+    steps:
+      - uses: actions/checkout@v6.0.1
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@2.36.0
+        with:
+          php-version: ${{ matrix.php }}
+          tools: composer:v2
+          coverage: xdebug
+
+      - name: Print Libxml Version
+        shell: bash
+        run: |
+          php -r 'echo "libxml: " . LIBXML_DOTTED_VERSION . PHP_EOL;'
+
+      - name: Install Composer Dependencies
+        uses: ramsey/composer-install@3.1.1
+
+      - name: Run Tests
+        run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ nbproject/*
 vendor/*
 composer.lock
 .idea/
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -14,11 +14,15 @@
         "ext-dom": "*"
     },
     "require-dev": {
-        "ivopetkov/docs-generator": "1.*"
+        "ivopetkov/docs-generator": "1.*",
+        "phpunit/phpunit": "^12.5"
     },
     "autoload": {
         "files": [
             "autoload.php"
         ]
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/src/HTML5DOMDocument.php
+++ b/src/HTML5DOMDocument.php
@@ -179,6 +179,11 @@ class HTML5DOMDocument extends \DOMDocument
                 $this->removeChild($item);
                 break;
             }
+            /** libxml 2.15+ converts <?xml ?> to comment instead of PI node */
+            if ($item->nodeType === XML_COMMENT_NODE && strpos($item->nodeValue, '?xml') === 0) {
+                $this->removeChild($item);
+                break;
+            }
         }
         /** @var HTML5DOMElement|null */
         $metaTagElement = $this->getElementsByTagName('meta')->item(0);

--- a/src/HTML5DOMDocument.php
+++ b/src/HTML5DOMDocument.php
@@ -13,7 +13,7 @@ use IvoPetkov\HTML5DOMDocument\Internal\QuerySelectors;
 
 /**
  * Represents a live (can be manipulated) representation of a HTML5 document.
- * 
+ *
  * @method \IvoPetkov\HTML5DOMElement|false createElement(string $localName, string $value = '') Create new element node.
  * @method \IvoPetkov\HTML5DOMElement|false createElementNS(?string $namespace, string $qualifiedName, string $value = '') Create new element node with an associated namespace.
  * @method ?\IvoPetkov\HTML5DOMElement getElementById(string $elementId) Searches for an element with a certain id.
@@ -129,6 +129,7 @@ class HTML5DOMDocument extends \DOMDocument
         $autoAddDoctype = !defined('LIBXML_HTML_NODEFDTD') || ($options & LIBXML_HTML_NODEFDTD) === 0;
 
         $allowDuplicateIDs = ($options & self::ALLOW_DUPLICATE_IDS) !== 0;
+        $options = $options & ~self::ALLOW_DUPLICATE_IDS;
 
         // Add body tag if missing
         if ($autoAddHtmlAndBodyTags && $source !== '' && preg_match('/\<!DOCTYPE.*?\>/', $source) === 0 && preg_match('/\<html.*?\>/', $source) === 0 && preg_match('/\<body.*?\>/', $source) === 0 && preg_match('/\<head.*?\>/', $source) === 0) {
@@ -227,7 +228,7 @@ class HTML5DOMDocument extends \DOMDocument
 
     /**
      * Load HTML from a file.
-     * 
+     *
      * @param string $filename The path to the HTML file.
      * @param integer $options Additional Libxml parameters.
      * @return boolean
@@ -418,7 +419,7 @@ class HTML5DOMDocument extends \DOMDocument
 
     /**
      * Dumps the internal document into a file using HTML formatting.
-     * 
+     *
      * @param string $filename The path to the saved HTML document.
      * @return int|false the number of bytes written or FALSE if an error occurred.
      */
@@ -631,7 +632,7 @@ class HTML5DOMDocument extends \DOMDocument
 
     /**
      * Applies the modifications specified to the DOM document.
-     * 
+     *
      * @param integer $modifications The modifications to apply. Available values:
      *  - HTML5DOMDocument::FIX_MULTIPLE_TITLES - removes all but the last title elements.
      *  - HTML5DOMDocument::FIX_DUPLICATE_METATAGS - removes all but the last metatags with matching name or property attributes.

--- a/src/HTML5DOMDocument.php
+++ b/src/HTML5DOMDocument.php
@@ -129,7 +129,6 @@ class HTML5DOMDocument extends \DOMDocument
         $autoAddDoctype = !defined('LIBXML_HTML_NODEFDTD') || ($options & LIBXML_HTML_NODEFDTD) === 0;
 
         $allowDuplicateIDs = ($options & self::ALLOW_DUPLICATE_IDS) !== 0;
-        $options = $options & ~self::ALLOW_DUPLICATE_IDS;
 
         // Add body tag if missing
         if ($autoAddHtmlAndBodyTags && $source !== '' && preg_match('/\<!DOCTYPE.*?\>/', $source) === 0 && preg_match('/\<html.*?\>/', $source) === 0 && preg_match('/\<body.*?\>/', $source) === 0 && preg_match('/\<head.*?\>/', $source) === 0) {
@@ -166,7 +165,7 @@ class HTML5DOMDocument extends \DOMDocument
             $source = "<!DOCTYPE html>\n" . $source;
         }
 
-        $result = parent::loadHTML('<?xml encoding="utf-8" ?>' . $source, $options | LIBXML_PARSEHUGE);
+        $result = parent::loadHTML('<?xml encoding="utf-8" ?>' . $source, $this->cleanupOptions($options) | LIBXML_PARSEHUGE);
         if ($internalErrorsOptionValue === false) {
             libxml_use_internal_errors(false);
         }
@@ -229,6 +228,14 @@ class HTML5DOMDocument extends \DOMDocument
 
         $this->loaded = true;
         return true;
+    }
+
+    /**
+     * Remove non-libxml options from the user-provided options
+     * to prevent unintended side-effects within the extension
+     */
+    private function cleanupOptions(int $options): int {
+        return $options & ~self::ALLOW_DUPLICATE_IDS;
     }
 
     /**

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -1515,6 +1515,17 @@ class Test extends PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test void tags in combination with HTML5DOMDocument::ALLOW_DUPLICATE_IDS
+     */
+    public function testVoidTagsWithAllowDuplicateIDs()
+    {
+        $dom = new \IvoPetkov\HTML5DOMDocument();
+        $dom->loadHTML('<p>foo <br /> bar</p><p> another paragraph </p>', HTML5DOMDocument::ALLOW_DUPLICATE_IDS);
+        $expectedResult = '<!DOCTYPE html><html><body><p>foo <br> bar</p></body></html>';
+        $this->assertEquals($expectedResult, $this->removeNewLines($dom->saveHTML()));
+    }
+
+    /**
      * 
      * @param string $text
      * @return string

--- a/tests/Test.php
+++ b/tests/Test.php
@@ -1251,7 +1251,7 @@ class Test extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * 
+     *
      */
     public function testWrongCharsetMetaTag()
     {
@@ -1444,7 +1444,7 @@ class Test extends PHPUnit\Framework\TestCase
     }
 
     /**
-     * 
+     *
      * @return void
      */
     public function testInternalEntityFromGetters()
@@ -1521,12 +1521,12 @@ class Test extends PHPUnit\Framework\TestCase
     {
         $dom = new \IvoPetkov\HTML5DOMDocument();
         $dom->loadHTML('<p>foo <br /> bar</p><p> another paragraph </p>', HTML5DOMDocument::ALLOW_DUPLICATE_IDS);
-        $expectedResult = '<!DOCTYPE html><html><body><p>foo <br> bar</p></body></html>';
+        $expectedResult = '<!DOCTYPE html><html><body><p>foo <br> bar</p><p> another paragraph </p></body></html>';
         $this->assertEquals($expectedResult, $this->removeNewLines($dom->saveHTML()));
     }
 
     /**
-     * 
+     *
      * @param string $text
      * @return string
      */


### PR DESCRIPTION
Fixes #63 
Replaces #64 

## Fixes

1. Cleanup the custom `ALLOW_DUPLICATE_IDS` flag (`67108864`) before passing `$options` to the native `DOMDocument::loadHTML()` as it seems to conflict with internal libxml flags in 2.15.1
2. libxml 2.15.1 converts `<?xml encoding="utf-8" ?>` to a HTML comment instead of `XML_PI_NODE`. Update removal logic to handle both node types for backward compatibility. I suspect the changed behavior is related to libxml becoming more spec-compliant. This looks very related: https://html.spec.whatwg.org/multipage/parsing.html#parse-error-unexpected-question-mark-instead-of-tag-name

## Notes
- I based this PR on my other PR #64 to benefit from the tooling added in that PR.
- Added a new test `testVoidTagsWithAllowDuplicateIDs` that fails without the new  `ALLOW_DUPLICATE_IDS` flag removal and passes with it
- After fix 2 above, all tests are passing for me except `Test::testComplexQuerySelectors` wich seems to be unrelated and should be fixed in another PR
- The last remaining failing test is related to the invalid `<div">` in the test fixture:

https://github.com/ivopetkov/html5-dom-document-php/blob/4e78d435c0a7eedc2ebc2919f28f22c322076b4e/tests/Test.php#L506

That one becomes `<div"><a href="#">text7</a></div">` in my environment. Was it intentional to support that syntax or is it a typo in the test fixture? Anyhow, I've [filed a bug report upstream](https://gitlab.gnome.org/GNOME/libxml2/-/issues?show=eyJpaWQiOiIxMDM5IiwiZnVsbF9wYXRoIjoiR05PTUUvbGlieG1sMiIsImlkIjoyMzQwMDF9).
