### PR TITLE
Downgrade PHPUnit to ^9.6 for PHP 8.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "ivopetkov/docs-generator": "1.*",
-        "phpunit/phpunit": "^12.5"
+        "phpunit/phpunit": "^9.6"
     },
     "autoload": {
         "files": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,9 +4,9 @@
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <source>
+    <coverage>
         <include>
             <directory>./src/</directory>
         </include>
-    </source>
+    </coverage>
 </phpunit>


### PR DESCRIPTION
As discussed in #66 : Downgrade PHPUnit to `^9.6` for PHP `8.0` compatibility.

- Tests are now running
- `Test::testFragments` is failing in CI. That test passes locally on my machine. I asked claude code about it. It pointed me to this: 
 
https://github.com/ivopetkov/html5-dom-document-php/blob/3d0915df6ffa3c386ec44fb9d64c7b4b56f11433/src/HTML5DOMDocument.php#L148-L156

```
When the input (<div>text</div>) has no <html> tag, it hits line 153:           
                                                                                                                     
$source = '<html><head>' . $charsetTag . '</head></html>' . $source;                                               
$removeHtmlTag = true;                                             
                                                                                                                   
It prepends <html><head><meta ...></head></html> before the fragment to inject a charset meta tag. Then after      
parsing, it tries to clean up (lines 189–194) by removing the temporary head/html tags.

But the key issue: on CI's libxml2, when this combined source is parsed with LIBXML_HTML_NOIMPLIED, libxml absorbs
the <div> into the <html> element rather than keeping it separate. So after cleanup removes the <head> and meta,
the <html> wrapper remains (with the <div> inside it) because $removeHtmlTag only removes the <html> if
$htmlElement->firstChild === null — which it isn't, since the <div> got folded into it.

So it's not a libxml2 bug per se — it's the library's charset injection interacting differently with
LIBXML_HTML_NOIMPLIED across libxml2 versions.
```

This is something to tackle in a separate PR. But running the tests in CI is already paying off I guess 🙂